### PR TITLE
Add pytest coverage for cis mapping workflows

### DIFF
--- a/tests/cis/test_common.py
+++ b/tests/cis/test_common.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pandas as pd
+import torch
+
+from src.localqtl.cis.common import (
+    dosage_vector_for_covariate,
+    residualize_matrix_with_covariates,
+    residualize_batch,
+)
+from src.localqtl.regression_kernels import Residualizer
+
+
+def test_dosage_vector_for_covariate_handles_reordering_and_imputation(toy_data):
+    genotype_df = toy_data["genotype_df"]
+    samples = toy_data["samples"]
+
+    # introduce a non-default sample order and confirm we respect it
+    shuffled_samples = list(reversed(samples))
+    row = dosage_vector_for_covariate(
+        genotype_df=genotype_df,
+        variant_id="v3_chr1_300",
+        sample_order=pd.Index(shuffled_samples),
+        missing=-9.0,
+    )
+
+    assert row.shape == (len(samples),)
+    # ensure mean-imputation replaced the -9.0 entry with the average of the observed values
+    observed = genotype_df.loc["v3_chr1_300", shuffled_samples].to_numpy()
+    mask = observed == -9.0
+    expected_mean = observed[~mask].mean(dtype=np.float32)
+    assert np.isclose(row[mask][0], expected_mean)
+    # and all remaining entries match the requested order
+    assert np.allclose(row[~mask], observed[~mask])
+
+
+def test_residualize_matrix_with_covariates_centers_rows():
+    Y = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float32)
+    cov = pd.DataFrame({"c1": [1.0, 2.0, 3.0]}, index=["s1", "s2", "s3"])
+
+    Y_resid, rez = residualize_matrix_with_covariates(Y, cov, device="cpu")
+
+    assert rez is not None
+    assert torch.allclose(Y_resid.sum(dim=1), torch.zeros(2), atol=1e-6)
+
+    # Without covariates the tensor should be returned unchanged
+    Y_passthrough, rez_none = residualize_matrix_with_covariates(Y, None, device="cpu")
+    assert rez_none is None
+    assert torch.allclose(Y_passthrough, Y)
+
+
+def test_residualize_batch_supports_grouped_and_scalar_inputs():
+    rez = Residualizer(torch.ones((3, 1)))
+    G = torch.arange(9, dtype=torch.float32).reshape(3, 3)
+
+    y = torch.tensor([1.0, 2.0, 4.0], dtype=torch.float32)
+    y_resid, G_resid, H_resid = residualize_batch(y, G, None, rez, center=True, group=False)
+    assert H_resid is None
+    assert y_resid.shape == (3,)
+    assert G_resid.shape == G.shape
+    assert torch.allclose(y_resid.sum(), torch.tensor(0.0), atol=1e-6)
+
+    grouped = [torch.tensor([1.0, 3.0, 5.0], dtype=torch.float32),
+               torch.tensor([2.0, 4.0, 6.0], dtype=torch.float32)]
+    y_list, G_group_resid, _ = residualize_batch(grouped, G, None, rez, center=True, group=True)
+    assert len(y_list) == 2
+    for vec in y_list:
+        assert vec.shape == (3,)
+        assert torch.allclose(vec.sum(), torch.tensor(0.0), atol=1e-6)
+    assert torch.equal(G_group_resid, G_resid)

--- a/tests/cis/test_independent.py
+++ b/tests/cis/test_independent.py
@@ -1,0 +1,44 @@
+import numpy as np
+import torch
+
+from src.localqtl.cis.independent import map_independent
+from src/localqtl.cis.permutations import map_permutations
+from src.localqtl.utils import SimpleLogger
+
+
+def test_map_independent_identifies_forward_backward_hits(toy_data):
+    torch.manual_seed(0)
+    base = map_permutations(
+        genotype_df=toy_data["genotype_df"],
+        variant_df=toy_data["variant_df"],
+        phenotype_df=toy_data["phenotype_df"],
+        phenotype_pos_df=toy_data["phenotype_pos_df"],
+        covariates_df=None,
+        device="cpu",
+        nperm=4,
+        seed=321,
+        logger=SimpleLogger(verbose=False),
+    )
+
+    cis_df = base.copy()
+    cis_df["qval"] = np.linspace(0.01, 0.03, len(cis_df))
+
+    result = map_independent(
+        genotype_df=toy_data["genotype_df"],
+        variant_df=toy_data["variant_df"],
+        cis_df=cis_df,
+        phenotype_df=toy_data["phenotype_df"],
+        phenotype_pos_df=toy_data["phenotype_pos_df"],
+        covariates_df=None,
+        device="cpu",
+        nperm=3,
+        seed=123,
+        logger=SimpleLogger(verbose=False),
+    )
+
+    assert not result.empty
+    assert {"phenotype_id", "variant_id", "rank", "pval_beta"}.issubset(result.columns)
+    # ranks should start at 1 for each phenotype
+    grouped = result.groupby("phenotype_id")["rank"]
+    for ranks in grouped:
+        assert ranks.iloc[0] == 1

--- a/tests/cis/test_init.py
+++ b/tests/cis/test_init.py
@@ -1,0 +1,12 @@
+import src.localqtl.cis as cis
+
+
+def test_cis_init_exports_symbols():
+    expected = {"map_nominal", "map_permutations", "map_independent", "CisMapper"}
+    assert set(cis.__all__) == expected
+
+    # Spot-check that the exported callables are usable
+    assert callable(cis.map_nominal)
+    assert callable(cis.map_permutations)
+    assert callable(cis.map_independent)
+    assert isinstance(cis.CisMapper.__name__, str)

--- a/tests/cis/test_mapper.py
+++ b/tests/cis/test_mapper.py
@@ -1,0 +1,78 @@
+import pandas as pd
+import pytest
+
+from src.localqtl.cis.mapper import CisMapper
+from src.localqtl.utils import SimpleLogger
+
+
+def _build_mapper(toy_data):
+    return CisMapper(
+        genotype_df=toy_data["genotype_df"],
+        variant_df=toy_data["variant_df"],
+        phenotype_df=toy_data["phenotype_df"],
+        phenotype_pos_df=toy_data["phenotype_pos_df"],
+        covariates_df=pd.DataFrame({"cov": [0.0, 1.0, 2.0, 3.0]}, index=toy_data["samples"]),
+        device="cpu",
+        logger=SimpleLogger(verbose=False),
+    )
+
+
+def test_cis_mapper_delegates_nominal(monkeypatch, toy_data):
+    mapper = _build_mapper(toy_data)
+    called = {}
+
+    def fake_nominal(**kwargs):
+        called.update(kwargs)
+        return pd.DataFrame({"phenotype_id": ["geneA"]})
+
+    monkeypatch.setattr("src.localqtl.cis.mapper._map_nominal", fake_nominal)
+
+    result = mapper.map_nominal(nperm=2, maf_threshold=0.5)
+
+    assert not result.empty
+    assert called["nperm"] == 2
+    assert called["maf_threshold"] == 0.5
+    assert called["device"] == "cpu"
+
+
+def test_cis_mapper_delegates_permutations(monkeypatch, toy_data):
+    mapper = _build_mapper(toy_data)
+    called = {}
+
+    def fake_perm(**kwargs):
+        called.update(kwargs)
+        return pd.DataFrame({"phenotype_id": ["geneA"], "pval_beta": [0.01]})
+
+    monkeypatch.setattr("src.localqtl.cis.mapper._map_permutations", fake_perm)
+
+    result = mapper.map_permutations(nperm=7, maf_threshold=0.3, seed=123)
+
+    assert not result.empty
+    assert called["nperm"] == 7
+    assert called["maf_threshold"] == 0.3
+    assert called["seed"] == 123
+
+
+def test_cis_mapper_delegates_independent(monkeypatch, toy_data):
+    mapper = _build_mapper(toy_data)
+    called = {}
+
+    def fake_independent(**kwargs):
+        called.update(kwargs)
+        return pd.DataFrame({"phenotype_id": ["geneA"], "rank": [1]})
+
+    monkeypatch.setattr("src.localqtl.cis.mapper._map_independent", fake_independent)
+
+    cis_df = pd.DataFrame({
+        "phenotype_id": ["geneA"],
+        "variant_id": ["v1_chr1_100"],
+        "pval_beta": [0.01],
+        "qval": [0.01],
+    })
+
+    result = mapper.map_independent(cis_df=cis_df, fdr=0.1, maf_threshold=0.2)
+
+    assert not result.empty
+    assert called["fdr"] == 0.1
+    assert called["maf_threshold"] == 0.2
+    assert called["cis_df"].equals(cis_df)

--- a/tests/cis/test_nominal.py
+++ b/tests/cis/test_nominal.py
@@ -1,0 +1,26 @@
+import numpy as np
+import torch
+
+from src.localqtl.cis.nominal import map_nominal
+from src.localqtl.utils import SimpleLogger
+
+
+def test_map_nominal_returns_all_pairs(toy_data):
+    torch.manual_seed(0)
+    result = map_nominal(
+        genotype_df=toy_data["genotype_df"],
+        variant_df=toy_data["variant_df"],
+        phenotype_df=toy_data["phenotype_df"],
+        phenotype_pos_df=toy_data["phenotype_pos_df"],
+        covariates_df=None,
+        device="cpu",
+        nperm=3,
+        logger=SimpleLogger(verbose=False),
+    )
+
+    assert {"phenotype_id", "variant_id", "pval_nominal", "perm_max_r2"}.issubset(result.columns)
+    # geneConst should be dropped; the remaining phenotypes must appear in the output
+    expected_ids = {pid for pid in toy_data["phenotype_df"].index if pid != "geneConst"}
+    assert set(result["phenotype_id"].unique()) == expected_ids
+    assert ((result["pval_nominal"] >= 0.0) & (result["pval_nominal"] <= 1.0)).all()
+    assert np.isfinite(result["perm_max_r2"]).all()

--- a/tests/cis/test_permutations.py
+++ b/tests/cis/test_permutations.py
@@ -1,0 +1,26 @@
+import numpy as np
+import torch
+
+from src.localqtl.cis.permutations import map_permutations
+from src.localqtl.utils import SimpleLogger
+
+
+def test_map_permutations_computes_empirical_stats(toy_data):
+    torch.manual_seed(0)
+    result = map_permutations(
+        genotype_df=toy_data["genotype_df"],
+        variant_df=toy_data["variant_df"],
+        phenotype_df=toy_data["phenotype_df"],
+        phenotype_pos_df=toy_data["phenotype_pos_df"],
+        covariates_df=None,
+        device="cpu",
+        nperm=5,
+        seed=123,
+        logger=SimpleLogger(verbose=False),
+    )
+
+    assert {"phenotype_id", "variant_id", "pval_perm", "pval_beta", "dof"}.issubset(result.columns)
+    expected_ids = {pid for pid in toy_data["phenotype_df"].index if pid != "geneConst"}
+    assert set(result["phenotype_id"]) == expected_ids
+    assert ((result["pval_perm"] >= 0.0) & (result["pval_perm"] <= 1.0)).all()
+    assert np.isfinite(result[["beta", "se", "tstat", "r2_nominal"]]).all().all()

--- a/tests/cis/test_postproc.py
+++ b/tests/cis/test_postproc.py
@@ -1,0 +1,68 @@
+import pandas as pd
+
+from src.localqtl.cis.postproc import _chrom_sort_key, get_significant_pairs
+from src.localqtl.utils import SimpleLogger
+
+
+def test_chrom_sort_key_handles_special_chromosomes():
+    chroms = ["chrX", "chr2", "chrM", "chr10", "chrY", "chr1", "custom"]
+    ordered = sorted(chroms, key=_chrom_sort_key)
+    assert ordered[:4] == ["chr1", "chr2", "chr10", "chrX"]
+    assert ordered[4:] == ["chrY", "chrM", "custom"]
+
+
+def _write_nominal(tmp_path, chrom, rows):
+    path = tmp_path / f"cis_nominal.{chrom}.parquet"
+    pd.DataFrame(rows).to_parquet(path, index=False)
+    return path
+
+
+def test_get_significant_pairs_filters_nominal_hits(tmp_path):
+    res_df = pd.DataFrame({
+        "phenotype_id": ["geneA", "geneB", "geneC"],
+        "qval": [0.01, 0.2, 0.03],
+        "pval_nominal_threshold": [0.05, 0.05, 0.01],
+    })
+
+    _write_nominal(tmp_path, "chr1", [
+        {"phenotype_id": "geneA", "variant_id": "v1", "pval_nominal": 0.04},
+        {"phenotype_id": "geneB", "variant_id": "v2", "pval_nominal": 0.01},
+    ])
+    _write_nominal(tmp_path, "chr2", [
+        {"phenotype_id": "geneC", "variant_id": "v3", "pval_nominal": 0.005},
+    ])
+
+    result = get_significant_pairs(
+        res_df=res_df,
+        nominal_files=str(tmp_path / "cis_nominal.chr*.parquet"),
+        fdr=0.05,
+        logger=SimpleLogger(verbose=False),
+    )
+
+    assert set(result["phenotype_id"]) == {"geneA", "geneC"}
+    assert (result["pval_nominal"] <= result["pval_nominal_threshold_pheno"]).all()
+
+
+def test_get_significant_pairs_group_mode(tmp_path):
+    res_df = pd.DataFrame({
+        "group_id": ["g1", "g2"],
+        "qval": [0.01, 0.2],
+        "pval_nominal_threshold": [0.02, 0.5],
+    })
+    group_s = pd.Series({"geneA": "g1", "geneB": "g1", "geneC": "g2"}, name="phenotype_id")
+
+    _write_nominal(tmp_path, "chr1", [
+        {"phenotype_id": "geneA", "variant_id": "v1", "pval_nominal": 0.01},
+        {"phenotype_id": "geneB", "variant_id": "v2", "pval_nominal": 0.5},
+    ])
+
+    result = get_significant_pairs(
+        res_df=res_df,
+        nominal_files={"chr1": tmp_path / "cis_nominal.chr1.parquet"},
+        group_s=group_s,
+        fdr=0.05,
+        logger=SimpleLogger(verbose=False),
+    )
+
+    assert set(result["group_id"]) == {"g1"}
+    assert (result["pval_nominal"] <= result["pval_nominal_threshold_group"]).all()


### PR DESCRIPTION
## Summary
- add focused unit tests for cis common utilities, mapper delegations, and public entry points
- exercise nominal, permutation, and independent cis mapping flows on deterministic toy data
- cover post-processing helpers that gather significant pairs from parquet outputs

------
https://chatgpt.com/codex/tasks/task_e_69035e2f63dc8323ac5beab93fefa4b6