### PR TITLE
Update localqtl package exports for new module layout

### DIFF
--- a/src/localqtl/__init__.py
+++ b/src/localqtl/__init__.py
@@ -1,16 +1,34 @@
-from . import phenotypeio
+"""Top-level package exports for :mod:`localqtl`.
+
+This module re-exports the most commonly used classes/functions so that they
+remain accessible from ``localqtl`` after the project was reorganized into a
+package with dedicated submodules (``cis``, ``preproc``, ``finemap`` …).
+"""
+
+from . import cis
+from . import finemap
 from . import genotypeio
 from . import haplotypeio
-from . import utils
+from . import iosinks
 from . import pgen
+from . import phenotypeio
+from . import preproc
+from . import regression_kernels
+from . import stats
+from . import utils
 
+from .cis import CisMapper, map_independent, map_nominal, map_permutations
+from .genotypeio import InputGeneratorCis, PlinkReader
+from .haplotypeio import InputGeneratorCisWithHaps, RFMixReader
 from .phenotypeio import read_phenotype_bed
-from .utils import gpu_available
-from .genotypeio import PlinkReader, InputGeneratorCis
-from .haplotypeio import RFMixReader, InputGeneratorCisWithHaps
 from .pgen import PgenReader
+from .utils import gpu_available
 
 __all__ = [
+    "map_nominal",
+    "map_permutations",
+    "map_independent",
+    "CisMapper",
     "read_phenotype_bed",
     "gpu_available",
     "PlinkReader",
@@ -18,9 +36,15 @@ __all__ = [
     "PgenReader",
     "InputGeneratorCis",
     "InputGeneratorCisWithHaps",
+    "cis",
+    "finemap",
     "phenotypeio",
     "genotypeio",
     "haplotypeio",
+    "iosinks",
     "pgen",
-    "utils"
+    "preproc",
+    "regression_kernels",
+    "stats",
+    "utils",
 ]


### PR DESCRIPTION
## Summary
- re-export cis mapping helpers and mapper from the new subpackage
- expose newly added modules in the package namespace to match the reorganized layout
- document the intent of the package-level re-exports

------
https://chatgpt.com/codex/tasks/task_e_6903650dbb2483238fc82f76497dbdf8