### PR TITLE
Add __all__ exports across localqtl modules

### DIFF
--- a/src/localqtl/cis/common.py
+++ b/src/localqtl/cis/common.py
@@ -5,6 +5,12 @@ from typing import Optional, Tuple, List
 
 from ..regression_kernels import Residualizer
 
+__all__ = [
+    "dosage_vector_for_covariate",
+    "residualize_matrix_with_covariates",
+    "residualize_batch",
+]
+
 def _make_gen(seed: int | None, device: str) -> torch.Generator | None:
     if seed is None:
         return None

--- a/src/localqtl/cis/independent.py
+++ b/src/localqtl/cis/independent.py
@@ -14,6 +14,10 @@ from ..regression_kernels import (
 )
 from .common import residualize_batch, dosage_vector_for_covariate
 
+__all__ = [
+    "map_independent",
+]
+
 def _run_independent_core(
         ig, variant_df: pd.DataFrame, covariates_df: Optional[pd.DataFrame],
         signif_seed_df: pd.DataFrame, signif_threshold: float, nperm: int,

--- a/src/localqtl/cis/mapper.py
+++ b/src/localqtl/cis/mapper.py
@@ -8,6 +8,10 @@ from .nominal import map_nominal as _map_nominal
 from .permutations import map_permutations as _map_permutations
 from .independent import map_independent as _map_independent
 
+__all__ = [
+    "CisMapper",
+]
+
 class CisMapper:
     """
     Thin convenience wrapper that delegates to the functional APIs:

--- a/src/localqtl/cis/nominal.py
+++ b/src/localqtl/cis/nominal.py
@@ -14,6 +14,10 @@ from ..regression_kernels import (
 )
 from .common import residualize_matrix_with_covariates, residualize_batch
 
+__all__ = [
+    "map_nominal",
+]
+
 def _run_nominal_core(ig, variant_df, rez, nperm, device, maf_threshold: float = 0.0,
                       chrom: str | None = None, sink: "ParquetSink | None" = None):
     """

--- a/src/localqtl/cis/permutations.py
+++ b/src/localqtl/cis/permutations.py
@@ -13,6 +13,10 @@ from ..regression_kernels import (
 )
 from .common import residualize_matrix_with_covariates, residualize_batch
 
+__all__ = [
+    "map_permutations",
+]
+
 def _run_permutation_core(ig, variant_df, rez, nperm: int, device: str,
                           beta_approx: bool = True, maf_threshold: float = 0.0,
                           seed: int | None = None) -> pd.DataFrame:

--- a/src/localqtl/cis/postproc.py
+++ b/src/localqtl/cis/postproc.py
@@ -6,6 +6,10 @@ from typing import Mapping, Optional, List, Union
 
 from ..utils import SimpleLogger
 
+__all__ = [
+    "get_significant_pairs",
+]
+
 def _chrom_sort_key(ch: str) -> tuple:
     """Robust chromosome sort: chr1..chr22, X=23, Y=24, MT/M=25, else lexicographic fallback."""
     s = os.path.basename(ch)

--- a/src/localqtl/finemap.py
+++ b/src/localqtl/finemap.py
@@ -1,6 +1,11 @@
 import torch
 import numpy as np
 
+__all__ = [
+    "get_pairwise_ld",
+    "get_ld_matrix",
+]
+
 def get_pairwise_ld(pgr, id1, id2=None, r2=True, use_torch=False, dtype=np.float32):
     """
     Compute LD (r or r²) between one or more variants.

--- a/src/localqtl/genotypeio.py
+++ b/src/localqtl/genotypeio.py
@@ -16,6 +16,16 @@ try:
 except ImportError as e:
     pgen = None
 
+__all__ = [
+    "BackgroundGenerator",
+    "background",
+    "print_progress",
+    "PlinkReader",
+    "load_genotypes",
+    "get_cis_ranges",
+    "InputGeneratorCis",
+]
+
 class BackgroundGenerator(threading.Thread):
     def __init__(self, generator, max_prefetch=10):
         threading.Thread.__init__(self)

--- a/src/localqtl/haplotypeio.py
+++ b/src/localqtl/haplotypeio.py
@@ -33,6 +33,12 @@ else:
     def get_array_module(x):
         return np
 
+# Public exports
+__all__ = [
+    "RFMixReader",
+    "InputGeneratorCisWithHaps",
+]
+
 # ----------------------------
 # Local ancestry readers
 # ----------------------------

--- a/src/localqtl/iosinks.py
+++ b/src/localqtl/iosinks.py
@@ -4,6 +4,10 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+__all__ = [
+    "ParquetSink",
+]
+
 class ParquetSink:
     """
     Minimal streaming Parquet writer with stable schema enforcement.

--- a/src/localqtl/pgen.py
+++ b/src/localqtl/pgen.py
@@ -13,6 +13,12 @@ import numpy as np
 import pandas as pd
 import pgenlib as pg
 
+__all__ = [
+    "read_pvar",
+    "read_psam",
+    "PgenReader",
+]
+
 
 def read_pvar(pvar_path):
     """Read pvar file as pd.DataFrame"""

--- a/src/localqtl/phenotypeio.py
+++ b/src/localqtl/phenotypeio.py
@@ -12,6 +12,10 @@ if gpu_available():
 else:
     cp = np
 
+__all__ = [
+    "read_phenotype_bed",
+]
+
 def read_phenotype_bed(path, as_tensor=False, device="cpu", dtype="float32"):
     """
     Load phenotype BED file into phenotype and position DataFrames or arrays.

--- a/src/localqtl/preproc.py
+++ b/src/localqtl/preproc.py
@@ -2,6 +2,13 @@
 ## https://github.com/broadinstitute/tensorqtl/blob/master/tensorqtl/core.py
 import torch
 
+__all__ = [
+    "impute_mean_and_filter",
+    "calculate_maf",
+    "allele_stats",
+    "filter_by_maf",
+]
+
 def impute_mean_and_filter(
         G_t: torch.Tensor, missing: float = -9.0,
         allow_nonfinite: bool = True, inplace: bool = False,

--- a/src/localqtl/regression_kernels.py
+++ b/src/localqtl/regression_kernels.py
@@ -1,5 +1,11 @@
 import torch
 
+__all__ = [
+    "Residualizer",
+    "run_batch_regression",
+    "run_batch_regression_with_permutations",
+]
+
 class Residualizer(object):
     """
     Residualizer for regressing out covariates from genotype/phenotype matrices.

--- a/src/localqtl/stats.py
+++ b/src/localqtl/stats.py
@@ -12,6 +12,14 @@ from scipy import stats
 from py_qvalue import qvalue, pi0est
 from typing import Optional, Sequence, Union
 
+__all__ = [
+    "beta_approx_pval",
+    "get_t_pval",
+    "t_two_sided_pval_torch",
+    "nominal_pvals_tensorqtl",
+    "calculate_qvalues",
+]
+
 def beta_approx_pval(r2_perm: np.ndarray, r2_true: float) -> tuple[float, float, float]:
     """
     Fit Beta(a,b) to permutation R^2 by method of moments and return:

--- a/src/localqtl/utils.py
+++ b/src/localqtl/utils.py
@@ -6,6 +6,14 @@ from typing import Optional
 from datetime import datetime
 from contextlib import contextmanager
 
+__all__ = [
+    "SimpleLogger",
+    "NullLogger",
+    "gpu_available",
+    "pick_device",
+    "subseed",
+]
+
 class SimpleLogger:
     def __init__(self, logfile: Optional[str] = None, verbose: bool = True,
                  timestamps: bool = False, timefmt: str = "%Y-%m-%d %H:%M:%S"):


### PR DESCRIPTION
## Summary
- add explicit `__all__` declarations to top-level localqtl modules to clarify their public API
- define exports for cis-mapping modules so nominal, permutation, and independent workflows are discoverable
- include utility and IO helpers in module exports for consistent package-wide namespace control

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6903653b7f6083238d1e562ecc48aac8