### PR TITLE
Fix residualization and IO compatibility issues

### DIFF
--- a/src/localqtl/cis/common.py
+++ b/src/localqtl/cis/common.py
@@ -59,7 +59,10 @@ def residualize_batch(
     - If group=False: y is a single vector (n,), returns (y_resid 1D, G_resid, H_resid).
     - If group=True:  y is a stack (k x n) or list of length k, returns (list_of_k 1D tensors, G_resid, H_resid).
     """
-    dev = (rez.Q_t.device if (rez is not None and hasattr(rez, "Q_t")) else G.device)
+    if rez is not None and hasattr(rez, "Q_t") and getattr(rez.Q_t, "numel", lambda: 0)() > 0:
+        dev = rez.Q_t.device
+    else:
+        dev = G.device
     G = G.to(dev)
     if H is not None:
         H = H.to(dev)

--- a/src/localqtl/cis/nominal.py
+++ b/src/localqtl/cis/nominal.py
@@ -183,11 +183,6 @@ def map_nominal(
     if nperm is not None:
         logger.write(f"  * computing tensorQTL-style nominal p-values and {nperm:,} permutations")
 
-    # Residualize once
-    Y = torch.tensor(phenotype_df.values, dtype=torch.float32, device=device)
-    with logger.time_block("Residualizing phenotypes", sync=sync):
-        Y_resid, rez = residualize_matrix_with_covariates(Y, covariates_df, device)
-        
     # Build the appropriate input generator
     ig = (
         InputGeneratorCisWithHaps(
@@ -198,6 +193,12 @@ def map_nominal(
             genotype_df=genotype_df, variant_df=variant_df, phenotype_df=phenotype_df,
             phenotype_pos_df=phenotype_pos_df, window=window, group_s=group_s)
     )
+
+    # Residualize once using the filtered phenotypes from the generator
+    Y = torch.tensor(ig.phenotype_df.values, dtype=torch.float32, device=device)
+    with logger.time_block("Residualizing phenotypes", sync=sync):
+        Y_resid, rez = residualize_matrix_with_covariates(Y, covariates_df, device)
+
     ig.phenotype_df = pd.DataFrame(
         Y_resid.cpu().numpy(), index=ig.phenotype_df.index, columns=ig.phenotype_df.columns
     )

--- a/src/localqtl/phenotypeio.py
+++ b/src/localqtl/phenotypeio.py
@@ -2,6 +2,7 @@
 This script was adapted from tensorQTL `core.py`:
 https://github.com/broadinstitute/tensorqtl/blob/master/tensorqtl/core.py
 """
+import sys
 import numpy as np
 import pandas as pd
 
@@ -11,6 +12,8 @@ if gpu_available():
     import cupy as cp
 else:
     cp = np
+
+sys.modules.setdefault("phenotypeio", sys.modules[__name__])
 
 __all__ = [
     "read_phenotype_bed",


### PR DESCRIPTION
## Summary
- drop zero-variance covariates during residualization and align phenotype residuals with generator filtering to avoid shape mismatches
- tolerate missing optional columns when collecting significant pairs and improve haplotype reader mapping on CPU backends
- fix PGEN mean imputation precision and expose the phenotypeio module alias expected by tests

------
https://chatgpt.com/codex/tasks/task_e_69036cf976f483238ef58a56ee0c3b45