### PR TITLE
Sort phenotype BED records when unsorted

### DIFF
--- a/src/localqtl/phenotypeio.py
+++ b/src/localqtl/phenotypeio.py
@@ -79,10 +79,11 @@ def read_phenotype_bed(path, as_tensor=False, device="cpu", dtype="float32"):
     pos_df = df[["chr", "start", "end"]].copy()
     df = df.drop(["chr", "start", "end"], axis=1)
 
-    # Sort check
-    sorted_pos = pos_df.sort_values(["chr", "start", "end"]).reset_index(drop=True)
-    if not pos_df.reset_index(drop=True).equals(sorted_pos):
-        raise ValueError("Positions in BED file must be sorted by chr/start/end")
+    # Ensure consistent ordering of phenotypes and positions
+    ordered_pos = pos_df.sort_values(["chr", "start", "end"])  # lexicographic
+    if not pos_df.index.equals(ordered_pos.index):
+        pos_df = ordered_pos
+        df = df.loc[pos_df.index]
 
     # Collapse start==end to pos
     if (pos_df["start"] == pos_df["end"]).all():

--- a/tests/test_phenotypeio.py
+++ b/tests/test_phenotypeio.py
@@ -35,7 +35,27 @@ def test_read_phenotype_bed_tensor_cpu(tmp_path):
         "s2": [2.0]
     })
     df.to_csv(bedfile, sep="\t", index=False)
-    
+
     arr, pos = ph.read_phenotype_bed(str(bedfile), as_tensor=True, device="cpu")
     assert isinstance(arr, np.ndarray)
     assert arr.shape == (1,2)
+
+
+def test_read_phenotype_bed_sorts_positions(tmp_path):
+    bedfile = tmp_path / "unsorted.bed"
+    df = pd.DataFrame({
+        "#chr": ["2", "1", "1"],
+        "start": [5, 10, 0],
+        "end": [6, 11, 1],
+        "id": ["g3", "g2", "g1"],
+        "s1": [3.0, 2.0, 1.0],
+        "s2": [4.0, 3.0, 2.0],
+    })
+    df.to_csv(bedfile, sep="\t", index=False)
+
+    pheno, pos = ph.read_phenotype_bed(str(bedfile))
+
+    # ensure positions are sorted lexicographically by chr/start/end
+    assert pheno.index.tolist() == ["g1", "g2", "g3"]
+    assert pos["chr"].tolist() == ["1", "1", "2"]
+    assert pos["pos"].tolist() == [1, 11, 6]


### PR DESCRIPTION
## Summary
- sort phenotype BED metadata and expression rows when the input file is not pre-sorted
- add regression test covering automatic sorting behavior

------
https://chatgpt.com/codex/tasks/task_e_6903e0d0a5cc8323afe1adb238af3b69