### PR TITLE
Avoid pandas metadata lookups in cis hot loops

### DIFF
--- a/src/localqtl/cis/independent.py
+++ b/src/localqtl/cis/independent.py
@@ -250,8 +250,8 @@ def _run_independent_core(
                     stop_pval = pval_perm
 
                 if stop_pval <= signif_threshold:
-                    var_id = variant_df.index.values[v_idx[ix]]
-                    var_pos = int(variant_df.iloc[v_idx[ix]]["pos"])
+                    var_id = idx_to_id[v_idx[ix]]
+                    var_pos = int(pos_arr[v_idx[ix]])
                     start_pos = ig.phenotype_start[pid]
                     end_pos = ig.phenotype_end[pid]
                     row = pd.Series({
@@ -302,6 +302,8 @@ def _run_independent_core_group( ## TODO: Needs updating
     out_rows = []
     var_in_frame = set(variant_df.index)
     geno_has_variant = set(ig.genotype_df.index)
+    idx_to_id = variant_df.index.to_numpy()
+    pos_arr = variant_df["pos"].to_numpy(np.int64, copy=False)
 
     if covariates_df is not None and not covariates_df.index.equals(ig.phenotype_df.columns):
         covariates_df = covariates_df.loc[ig.phenotype_df.columns]
@@ -432,8 +434,8 @@ def _run_independent_core_group( ## TODO: Needs updating
                 break
 
             pid_best = ids[best["ix_pheno"]]
-            var_id = variant_df.index.values[v_idx[best["ix_var"]]]
-            var_pos = int(variant_df.iloc[v_idx[best["ix_var"]]]["pos"])
+            var_id = idx_to_id[v_idx[best["ix_var"]]]
+            var_pos = int(pos_arr[v_idx[best["ix_var"]]])
             start_pos = ig.phenotype_start[pid_best]
             end_pos = ig.phenotype_end[pid_best]
 
@@ -544,8 +546,8 @@ def _run_independent_core_group( ## TODO: Needs updating
 
                 if stop_pval <= signif_threshold:
                     pid_best = ids[best["ix_pheno"]]
-                    var_id = variant_df.index.values[v_idx[best["ix_var"]]]
-                    var_pos = int(variant_df.iloc[v_idx[best["ix_var"]]]["pos"])
+                    var_id = idx_to_id[v_idx[best["ix_var"]]]
+                    var_pos = int(pos_arr[v_idx[best["ix_var"]]])
                     start_pos = ig.phenotype_start[pid_best]
                     end_pos = ig.phenotype_end[pid_best]
 


### PR DESCRIPTION
## Summary
- precompute variant ID and position arrays once per cis mapping routine
- replace repeated pandas indexing in permutation and independent mapping loops with NumPy indexing

## Testing
- pytest tests/cis *(fails: cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorInsufficientDriver)*

------
https://chatgpt.com/codex/tasks/task_e_6904c04ac5ac83238aec6340222b8b78