### PR TITLE
Fix nominal mapping return value and logging

### DIFF
--- a/src/localqtl/cis/nominal.py
+++ b/src/localqtl/cis/nominal.py
@@ -379,8 +379,7 @@ def map_nominal(
                             logger=logger,
                             total_phenotypes=chrom_total,
                         )
-                    logger.write(f"chr{chrom}: ~{sink.rows:,} rows written")
-                logger.write(f"chr{chrom}: ~{sink.rows:,} rows written")
+                        logger.write(f"chr{chrom}: ~{sink.rows:,} rows written")
                 if logger.verbose:
                     elapsed = time.time() - chrom_start
                     logger.write(f"    Chromosome {chrom} completed in {elapsed:.2f}s")
@@ -398,5 +397,5 @@ def map_nominal(
     if logger.verbose:
         elapsed = time.time() - overall_start
         logger.write(f"    Completed nominal scan in {elapsed:.2f}s")
-    return result
+    return results
     


### PR DESCRIPTION
## Summary
- ensure map_nominal returns computed results when not streaming to disk
- avoid double logging of chromosome row counts during per-chromosome scans

## Testing
- pytest tests/cis/test_nominal.py::test_map_nominal_returns_results_when_no_output_dir *(fails: cuda driver unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69054eefe0ec83239c10ee8d48d818f4