### PR TITLE
Add optional haplotype preloading for cis nominal mapping

### DIFF
--- a/src/localqtl/utils.py
+++ b/src/localqtl/utils.py
@@ -64,7 +64,10 @@ class NullLogger(SimpleLogger):
 def gpu_available():
     try:
         import cupy as cp
-        ndev = cp.cuda.runtime.getDeviceCount()
+        try:
+            ndev = cp.cuda.runtime.getDeviceCount()
+        except cp.cuda.runtime.CUDARuntimeError:
+            return False
         return ndev > 0
     except ModuleNotFoundError:
         return False

--- a/tests/cis/test_nominal.py
+++ b/tests/cis/test_nominal.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 
 from src.localqtl.cis.nominal import map_nominal
@@ -15,6 +16,7 @@ def test_map_nominal_returns_all_pairs(toy_data):
         covariates_df=None,
         device="cpu",
         nperm=3,
+        out_dir=None,
         logger=SimpleLogger(verbose=False),
     )
 
@@ -24,3 +26,28 @@ def test_map_nominal_returns_all_pairs(toy_data):
     assert set(result["phenotype_id"].unique()) == expected_ids
     assert ((result["pval_nominal"] >= 0.0) & (result["pval_nominal"] <= 1.0)).all()
     assert np.isfinite(result["perm_max_r2"]).all()
+
+
+@pytest.mark.parametrize("preload", [True, False])
+def test_map_nominal_preload_option(toy_hap_data_2anc, preload):
+    torch.manual_seed(0)
+    result = map_nominal(
+        genotype_df=toy_hap_data_2anc["genotype_df"],
+        variant_df=toy_hap_data_2anc["variant_df"],
+        phenotype_df=toy_hap_data_2anc["phenotype_df"],
+        phenotype_pos_df=toy_hap_data_2anc["phenotype_pos_df"],
+        covariates_df=None,
+        haplotypes=toy_hap_data_2anc["haplotypes"],
+        loci_df=toy_hap_data_2anc["loci_df"],
+        group_s=None,
+        maf_threshold=0.0,
+        window=200,
+        nperm=None,
+        device="cpu",
+        out_dir=None,
+        preload_haplotypes=preload,
+        logger=SimpleLogger(verbose=False),
+    )
+
+    assert not result.empty
+    assert "pval_nominal" in result.columns


### PR DESCRIPTION
## Summary
- add a `preload_to_torch` path in `InputGeneratorCisWithHaps` that caches haplotypes on the requested torch device and reuses tensor views during batching
- expose a `preload_haplotypes` toggle in `map_nominal` and ensure haplotype batches avoid redundant conversions when tensors are already device-resident
- harden GPU detection against missing CUDA drivers and extend unit tests for the new preload behavior

## Testing
- pytest tests/test_haplotypeio.py tests/cis/test_nominal.py


------
https://chatgpt.com/codex/tasks/task_e_6906120e07cc832383fb0f2111194125