### PR TITLE
revert back and add optional tensorqtl version of degrees of freedom

### DIFF
--- a/src/localqtl/cis/common.py
+++ b/src/localqtl/cis/common.py
@@ -54,7 +54,8 @@ def dosage_vector_for_covariate(
 
 
 def residualize_matrix_with_covariates(
-        Y: torch.Tensor, C: Optional[pd.DataFrame], device: str
+        Y: torch.Tensor, C: Optional[pd.DataFrame], device: str,
+        tensorqtl_flavor: bool = False
 ) -> Tuple[torch.Tensor, Optional[Residualizer]]:
     """
     Residualize (features x samples) matrix Y against covariates C across samples.
@@ -64,7 +65,7 @@ def residualize_matrix_with_covariates(
         return Y, None
     dev = resolve_device(device)
     C_t = torch.tensor(C.values, dtype=torch.float32, device=dev)
-    rez = Residualizer(C_t)
+    rez = Residualizer(C_t, tensorqtl_flavor=tensorqtl_flavor)
     (Y_resid,) = rez.transform(move_to_device(Y, dev), center=True)
     return Y_resid, rez
 

--- a/src/localqtl/cis/mapper.py
+++ b/src/localqtl/cis/mapper.py
@@ -38,6 +38,7 @@ class CisMapper:
             out_prefix: str = "cis_nominal",
             compression: str = "snappy",
             return_df: bool = False,
+            tensorqtl_flavor: bool = False,
             logger: Optional[SimpleLogger] = None,
             verbose: bool = True,
     ):
@@ -58,6 +59,7 @@ class CisMapper:
         self.out_prefix = out_prefix
         self.compression = compression
         self.return_df = return_df
+        self.tensorqtl_flavor = tensorqtl_flavor
 
         self.logger = logger or SimpleLogger(verbose=verbose, timestamps=True)
 
@@ -85,6 +87,7 @@ class CisMapper:
             compression=self.compression,
             return_df=self.return_df,
             logger=self.logger,
+            tensorqtl_flavor=self.tensorqtl_flavor,
             verbose=getattr(self.logger, "verbose", True),
         )
 
@@ -110,6 +113,7 @@ class CisMapper:
             beta_approx=beta_approx,
             seed=seed,
             logger=self.logger,
+            tensorqtl_flavor=self.tensorqtl_flavor,
             verbose=getattr(self.logger, "verbose", True),
         )
 
@@ -141,6 +145,7 @@ class CisMapper:
             beta_approx=beta_approx,
             seed=seed,
             logger=self.logger,
+            tensorqtl_flavor=self.tensorqtl_flavor,
             verbose=getattr(self.logger, "verbose", True),
         )
 
@@ -150,8 +155,7 @@ class CisMapper:
     ) -> pd.DataFrame:
         """Annotate permutation results with q-values via :func:`calculate_qvalues`."""
         return _calculate_qvalues(
-            perm_df,
-            fdr=fdr,
+            perm_df, fdr=fdr,
             qvalue_lambda=qvalue_lambda,
             logger=self.logger,
         )

--- a/src/localqtl/stats.py
+++ b/src/localqtl/stats.py
@@ -67,7 +67,7 @@ def _beta_mle_on_p(p):
     return float(a), float(b)
 
 
-def beta_approx_pval(r2_perm, r2_true, dof_init):
+def beta_approx_pval_tensor(r2_perm, r2_true, dof_init):
     """
     Fit Beta(a,b) to permutation R^2 using tensorQTL method.
     """
@@ -79,6 +79,33 @@ def beta_approx_pval(r2_perm, r2_true, dof_init):
     return p_beta, a, b, true_dof, p_true
 
 
+def beta_approx_pval(r2_perm, r2_true, dof_init):
+    """
+    Fit Beta(a,b) to permutation R^2 by method of moments and return:
+        (pval_beta, a_hat, b_hat).
+    Falls back to empirical tail if variance is ~0 or invalid.
+    """
+    r2_perm = np.asarray(r2_perm, dtype=np.float64)
+    if r2_perm.size == 0 or not np.isfinite(r2_perm).all():
+        # Degenerate input: return NA-like outputs
+        return float("nan"), float("nan"), float("nan"), float("nan"), float("nan")
+
+    mu = r2_perm.mean()
+    var = r2_perm.var(ddof=1)
+    if not np.isfinite(mu) or not np.isfinite(var) or var <= 1e-12:
+        # Use empirical tail as a safe fallback
+        p_emp = (np.sum(r2_perm >= r2_true) + 1) / (r2_perm.size + 1)
+        return float(p_emp), float("nan"), float("nan")
+
+    # Method-of-moments for Beta
+    k = mu * (1.0 - mu) / var - 1.0
+    a = max(mu * k, 1e-6)
+    b = max((1.0 - mu) * k, 1e-6)
+
+    p_beta = 1.0 - stats.beta.cdf(r2_true, a, b)
+    return float(p_beta), float(a), float(b), dof_init, 0
+
+    
 def get_t_pval(t, df, two_tailed: bool = True, log10: bool = False):
     """
     Numerically stable p-values for Student's t.


### PR DESCRIPTION
This:
1. Reverts back to my version of beta-approximation
2. Adds option for calculating dof using the tensorqtl version, which does not account for when covariates have zero variance or colinearity

This is for attempt to match tensorqtl behavior