### PR TITLE
docs: refresh RTD content for latest APIs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,20 @@
 import os, sys, pathlib
+from unittest import mock
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT))
+os.environ.setdefault("READTHEDOCS", "True")
+
+_MOCK_MODULES = [
+    "torch", "cupy", "cudf", "rfmix_reader",
+    "pyarrow", "pyarrow.parquet",
+    "dask", "dask_cuda", "rapids_dask_dependency",
+    "numba", "pandas_plink", "pgen",
+]
+for _mod in _MOCK_MODULES:
+    sys.modules.setdefault(_mod, mock.MagicMock())
 
 project = "localQTL"
 extensions = [
@@ -24,9 +36,10 @@ autodoc_default_options = {
 
 # Mock heavy deps not available on RTD
 autodoc_mock_imports = [
-    "torch", "cupy", "cudf", "rfmix-reader", 
-    "pyarrow", "dask_cuda", "numba", "pandas_plink",
-    "dask"
+    "torch", "cupy", "cudf", "rfmix_reader",
+    "pyarrow", "pyarrow.parquet",
+    "dask", "dask_cuda", "rapids_dask_dependency",
+    "numba", "pandas_plink", "pgen",
 ]
 
 # Optional: keep type hints in descriptions for cleaner sigs


### PR DESCRIPTION
## Summary
- expand the user guide with device selection, logging, streaming sinks, and statistics usage that mirror the latest code paths
- restructure the API reference into cross-referenced sections covering cis mapping, I/O helpers, utilities, and regression kernels
- update the Sphinx configuration to mock heavy optional dependencies so Read the Docs builds can import the package reliably

## Testing
- poetry run sphinx-build -b html docs docs/_build/html

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69147d7011c083238cc45cc9e1da49c2)